### PR TITLE
Adds support for JSON 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SwaggerMarkdown"
 uuid = "1b6eb727-ad4b-44eb-9669-b9596a6e760f"
 authors = ["Jiacheng Zhang <zhangjiacheng54@gmail.com>"]
-version = "0.3"
+version = "0.3.1"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -12,7 +12,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 Aqua = "0.6, 0.7, 0.8"
-JSON = "0.21.1"
+JSON = "1"
 JSONSchema = "0.3, 1"
 RelocatableFolders = "1.0.1"
 Test = "1"

--- a/src/OpenAPI.jl
+++ b/src/OpenAPI.jl
@@ -49,7 +49,7 @@ function Base.showerror(io::IO, e::InvalidSwaggerSpecificationException)
 end
 
 
-function validate_spec(spec::Dict{String, Any})
+function validate_spec(spec::AbstractDict{<:AbstractString,<:Any})
 
     @assert (haskey(spec, "swagger") || haskey(spec, "openapi")) "Field 'swagger' (v2) or 'openapi' (v3) is missing"
 


### PR DESCRIPTION
Bumps Project.toml to support JSON 1.0. Needed a minor relaxation of the type that is passed into the `validate_spec` function for tests to pass.

While the tests pass, I notice that there are "duplicate key detected in mapping" error messages that appear in the output of the test suite as well. These errors are unrelated to bumping JSON to 1.0 as they appear with the previous version as well.